### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+---
+sudo: required
+sevices:
+  - docker
+
+language: python
+python:
+  - '2.7'
+
+env:
+#  - OPENSHIFT_VERSION=latest
+  - OPENSHIFT_VERSION=v3.9
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo sed -i "s/\DOCKER_OPTS=\"/DOCKER_OPTS=\"--insecure-registry=172.30.0.0\/16 /g" /etc/default/docker
+  - sudo cat /etc/default/docker
+  - sudo service docker restart
+
+# Test Stage
+script:
+  - ./tests/prepare.sh
+  - ./tests/verify.sh
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Elasticsearch images for OpenShift
 
+[![Build Status](https://travis-ci.org/ansibleplaybookbundle/es-apb.svg?branch=master)](https://travis-ci.org/RHsyseng/docker-rhel-elasticsearch)
+
 This image includes the [elasticsearch-cloud-kubernetes](https://github.com/fabric8io/elasticsearch-cloud-kubernetes) plugin pre-installed along with
 a default jvm configuration to get the Heap configuration from the cgroups.
 

--- a/es-cluster-deployment.yml
+++ b/es-cluster-deployment.yml
@@ -7,7 +7,7 @@ metadata:
       [{
       "from": {
         "kind": "ImageStreamTag",
-        "name": "elasticsearch:6.2.2"
+        "name": "elasticsearch:latest"
         },
         "fieldPath": "spec.template.spec.containers[?(@.name==\"elasticsearch\")].image"
       }]
@@ -32,9 +32,21 @@ spec:
           value: elasticsearch-cluster
         - name: LOG_LEVEL
           value: info
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: ' '
         imagePullPolicy: IfNotPresent
         name: elasticsearch
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9200
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9200
         ports:
         - containerPort: 9200
           name: api

--- a/tests/prepare.sh
+++ b/tests/prepare.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+export PROJECT_NAME=docker-rhel-elasticsearch
+
+function prepare() {
+  sudo docker cp $(docker create docker.io/openshift/origin:$OPENSHIFT_VERSION):/bin/oc /usr/local/bin/oc
+  oc cluster up --version=$OPENSHIFT_VERSION
+  oc login -u system:admin
+  export REGISTRY_URL=$(oc get svc -n default docker-registry -o jsonpath='{.spec.clusterIP}:{.spec.ports[0].port}')
+  oc login -u developer -p developer
+  oc new-project $PROJECT_NAME
+}
+
+function build() {
+  docker build -f Dockerfile.centos7 . -t $REGISTRY_URL/$PROJECT_NAME/elasticsearch:latest
+}
+
+function deploy() {
+  docker login -u `oc whoami` -p `oc whoami -t` $REGISTRY_URL
+  docker push $REGISTRY_URL/$PROJECT_NAME/elasticsearch:latest
+  oc create -f es-cluster-deployment.yml
+  oc policy add-role-to-user view -z elasticsearch
+}
+
+prepare
+
+build
+
+deploy

--- a/tests/verify.sh
+++ b/tests/verify.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+count=0
+max_count=20
+replicas=$(oc get sts elasticsearch -o jsonpath='{.spec.replicas}')
+ready_replicas=0
+
+while [[ $count -lt $max_count && ( -z $replicas || ! $replicas -eq $ready_replicas ) ]]
+do
+  sleep 2
+  ready_replicas=$(oc get sts elasticsearch -o jsonpath='{.status.readyReplicas}')
+  count=$((count+1))
+  echo "Retry $count out of $max_count"
+done
+
+if [ $max_count == $count ]; then
+  echo "Timeout waiting for Elasticsearch replicas to be ready $ready_replicas / $replicas"
+  exit 1
+fi
+
+echo Ready replicas is equals to the expected replicas $ready_replicas / $replicas
+
+ES_SVC=$(oc get svc elasticsearch -o jsonpath='{.spec.clusterIP}')
+
+count=0
+NODES=0
+
+while [[ $count -lt $max_count && ! $NODES -eq $replicas ]]; do
+  sleep 2
+  NODES=$(curl -s http://$ES_SVC:9200/_cat/nodes | wc -l)
+  count=$((count+1))
+  echo "Retry $count out of $max_count"
+done
+
+if [ ! $NODES -eq $replicas ]; then
+  echo "Expecting $replicas nodes in the cluster, got $NODES"
+  exit 1
+fi
+
+echo "Successfully checked cluster size is equals to the number of replicas $replicas"


### PR DESCRIPTION
Added Travis integration and liveness/readiness probes
The checks will compare the number of spec.replicas with the number of readyReplicas, then will compare the number of spec.replicas with the number of nodes in the cluster to confirm cluster discovery is working as well