### PR TITLE
Remove elasticsearch-cloud-kubernetes plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ ENV ES_CLOUD_K8S_VER=${ES_VERSION} \
     HOME=/opt/app-root/src \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    SERVICE=es-cluster \
-    NAMESPACE=elasticsearch
+    ES_CLUSTER_SERVICE=elasticsearch-cluster
 
 
 LABEL io.k8s.description="Elasticsearch container" \

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -15,8 +15,7 @@ ENV ES_CLOUD_K8S_VER=${ES_VERSION} \
     HOME=/opt/app-root/src \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    SERVICE=es-cluster \
-    NAMESPACE=elasticsearch
+    ES_CLUSTER_SERVICE=elasticsearch-cluster
 
 
 LABEL io.k8s.description="Elasticsearch container" \

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Build Status](https://travis-ci.org/RHsyseng/docker-rhel-elasticsearch.svg?branch=5.x)](https://travis-ci.org/RHsyseng/docker-rhel-elasticsearch)
 
-This image includes the [elasticsearch-cloud-kubernetes](https://github.com/fabric8io/elasticsearch-cloud-kubernetes) plugin pre-installed along with
-a default jvm configuration to get the Heap configuration from the cgroups.
+This image includes a default jvm configuration to get the Heap configuration from the cgroups.
 
  * [RHEL 7.3 image](./Dockerfile)
  * [CentOS 7 image](./Dockerfile.centos7)
@@ -18,16 +17,6 @@ service "elasticsearch" created
 service "elasticsearch-cluster" created
 imagestream "elasticsearch" created
 serviceaccount "elasticsearch" created
-```
-
-The elasticsearch-cloud-kubernetes plugin requires the ServiceAccount to be allowed to get the endpoints:
-```bash
-$ oc adm policy add-role-to-user view -z elasticsearch
-$ oc env statefulset/elasticsearch NAMESPACE=`oc project -q`
-```
-Now restart all Elasticsearch pods to apply the configuration change:
-```bash
-$ oc delete po -l app=elasticsearch
 ```
 
 ## Delete all resources

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -4,13 +4,9 @@ network:
   host: 0.0.0.0
 node:
   name: ${HOSTNAME}
-cloud:
-  kubernetes:
-    service: ${SERVICE}
-    namespace: ${NAMESPACE}
 discovery:
-  zen.hosts_provider: kubernetes
-  zen.minimum_master_nodes: "${NODE_QUORUM}"
+  zen.ping.unicast.hosts: ${ES_CLUSTER_SERVICE}
+  zen.minimum_master_nodes: ${NODE_QUORUM}
 path:
   data: /elasticsearch/persistent/elasticsearch/data
   logs: /elasticsearch/logs

--- a/es-cluster-deployment.yml
+++ b/es-cluster-deployment.yml
@@ -32,10 +32,6 @@ spec:
           value: elasticsearch-cluster
         - name: LOG_LEVEL
           value: info
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         image: ' '
         imagePullPolicy: IfNotPresent
         name: elasticsearch

--- a/install.sh
+++ b/install.sh
@@ -3,11 +3,7 @@
 set -ex
 set -o nounset
 
-# list of plugins to be installed
-if [ -z "${ES_CLOUD_K8S_URL:-}" ] ; then
-    ES_CLOUD_K8S_URL=io.fabric8:elasticsearch-cloud-kubernetes:${ES_CLOUD_K8S_VER}
-fi
-es_plugins=($ES_CLOUD_K8S_URL)
+es_plugins=("")
 
 echo "ES plugins: ${es_plugins[@]}"
 for es_plugin in ${es_plugins[@]}


### PR DESCRIPTION
Resolves #9 

elasticsearch-cloud-kubernetes is not needed,
descovery is be done via zen plugin and k8s discovery

Signed-off-by: Pavol Loffay <ploffay@redhat.com>