### PR TITLE
Remove elasticsearch-cloud-kubernetes plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,6 @@ RUN yum install -y --setopt=tsflags=nodocs \
     yum clean all
 
 COPY install.sh ${HOME}/
-# BEGIN - While elasticsearch-cloud-kubernetes-6.2.2 is not available on maven repo
-COPY elasticsearch-cloud-kubernetes-6.2.2-SNAPSHOT.zip ${HOME}
-ENV ES_CLOUD_K8S_URL=file://${HOME}/elasticsearch-cloud-kubernetes-6.2.2-SNAPSHOT.zip
-# END
 COPY config/* ${ES_PATH_CONF}/
 RUN ${HOME}/install.sh && \
   rm ${HOME}/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ ENV ES_CLOUD_K8S_VER=${ES_VERSION} \
     HOME=/opt/app-root/src \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    SERVICE=es-cluster \
-    NAMESPACE=elasticsearch
+    ES_CLUSTER_SERVICE=elasticsearch-cluster
 
 
 LABEL io.k8s.description="Elasticsearch container" \

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -34,10 +34,6 @@ RUN yum install -y --setopt=tsflags=nodocs \
     yum clean all
 
 COPY install.sh ${HOME}/
-# BEGIN - While elasticsearch-cloud-kubernetes-6.2.2 is not available on maven repo
-COPY elasticsearch-cloud-kubernetes-6.2.2-SNAPSHOT.zip ${HOME}
-ENV ES_CLOUD_K8S_URL=file://${HOME}/elasticsearch-cloud-kubernetes-6.2.2-SNAPSHOT.zip
-# END
 COPY config/* ${ES_PATH_CONF}/
 RUN ${HOME}/install.sh && \
   rm ${HOME}/*

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -15,8 +15,7 @@ ENV ES_CLOUD_K8S_VER=${ES_VERSION} \
     HOME=/opt/app-root/src \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    SERVICE=es-cluster \
-    NAMESPACE=elasticsearch
+    ES_CLUSTER_SERVICE=elasticsearch-cluster
 
 
 LABEL io.k8s.description="Elasticsearch container" \

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Build Status](https://travis-ci.org/RHsyseng/docker-rhel-elasticsearch.svg?branch=master)](https://travis-ci.org/RHsyseng/docker-rhel-elasticsearch)
 
-This image includes the [elasticsearch-cloud-kubernetes](https://github.com/fabric8io/elasticsearch-cloud-kubernetes) plugin pre-installed along with
-a default jvm configuration to get the Heap configuration from the cgroups.
+This image includes a default jvm configuration to get the Heap configuration from the cgroups.
 
  * [RHEL 7.3 image](./Dockerfile)
  * [CentOS 7 image](./Dockerfile.centos7)
@@ -19,8 +18,8 @@ service "elasticsearch-cluster" created
 imagestream "elasticsearch" created
 serviceaccount "elasticsearch" created
 ```
-The elasticsearch-cloud-kubernetes plugin requires the ServiceAccount to be allowed to get the endpoints
-```
-$ oc adm policy add-role-to-user view -z elasticsearch
-$ oc env statefulset/elasticsearch NAMESPACE=`oc project -q`
-```
+
+## Delete all resources
+```bash
+$ oc delete all -l app=elasticsearch
+``

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ statefulset "elasticsearch" created
 service "elasticsearch" created
 service "elasticsearch-cluster" created
 imagestream "elasticsearch" created
-serviceaccount "elasticsearch" created
 ```
 
 ## Delete all resources
 ```bash
 $ oc delete all -l app=elasticsearch
-``
+```

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -4,13 +4,9 @@ network:
   host: 0.0.0.0
 node:
   name: ${HOSTNAME}
-cloud:
-  kubernetes:
-    service: ${SERVICE}
-    namespace: ${NAMESPACE}
 discovery:
-  zen.hosts_provider: kubernetes
-  zen.minimum_master_nodes: "${NODE_QUORUM}"
+  zen.ping.unicast.hosts: ${ES_CLUSTER_SERVICE}
+  zen.minimum_master_nodes: ${NODE_QUORUM}
 path:
   data: /elasticsearch/persistent/elasticsearch/data
   logs: /elasticsearch/logs

--- a/es-cluster-deployment.yml
+++ b/es-cluster-deployment.yml
@@ -32,10 +32,6 @@ spec:
           value: elasticsearch-cluster
         - name: LOG_LEVEL
           value: info
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         image: ' '
         imagePullPolicy: IfNotPresent
         name: elasticsearch
@@ -63,8 +59,6 @@ spec:
         - mountPath: /elasticsearch/persistent
           name: elasticsearch-persistent
       securityContext: {}
-      serviceAccount: elasticsearch
-      serviceAccountName: elasticsearch
       volumes:
       - emptyDir: {}
         name: elasticsearch-persistent
@@ -101,6 +95,7 @@ spec:
   selector:
     app: elasticsearch
   type: ClusterIP
+  clusterIP: None
 ---
 apiVersion: v1
 kind: ImageStream
@@ -128,10 +123,3 @@ spec:
     from:
       kind: DockerImage
       name: registry.centos.org/rhsyseng/elasticsearch:5.5.2
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: elasticsearch
-  labels:
-    app: elasticsearch

--- a/install.sh
+++ b/install.sh
@@ -3,11 +3,7 @@
 set -ex
 set -o nounset
 
-# list of plugins to be installed
-if [ -z "${ES_CLOUD_K8S_URL:-}" ] ; then
-    ES_CLOUD_K8S_URL=io.fabric8:elasticsearch-cloud-kubernetes:${ES_CLOUD_K8S_VER}
-fi
-es_plugins=($ES_CLOUD_K8S_URL)
+es_plugins=("")
 
 echo "ES plugins: ${es_plugins[@]}"
 for es_plugin in ${es_plugins[@]}


### PR DESCRIPTION
Port of https://github.com/RHsyseng/docker-rhel-elasticsearch/pull/22 to master

elasticsearch-cloud-kubernetes is not needed,
descovery is be done via zen plugin and k8s discovery

Signed-off-by: Pavol Loffay <ploffay@redhat.com>