### PR TITLE
Remove service account

### DIFF
--- a/es-cluster-deployment.yml
+++ b/es-cluster-deployment.yml
@@ -59,8 +59,6 @@ spec:
         - mountPath: /elasticsearch/persistent
           name: elasticsearch-persistent
       securityContext: {}
-      serviceAccount: elasticsearch
-      serviceAccountName: elasticsearch
       volumes:
       - emptyDir: {}
         name: elasticsearch-persistent
@@ -124,10 +122,3 @@ spec:
     from:
       kind: DockerImage
       name: registry.centos.org/rhsyseng/elasticsearch:5.5.2
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: elasticsearch
-  labels:
-    app: elasticsearch


### PR DESCRIPTION
Resolves #27 

Service account was needed for f8c kubernetes plugin

Signed-off-by: Pavol Loffay <ploffay@redhat.com>