### PR TITLE
Deploy 3 master nodes

### DIFF
--- a/es-cluster-deployment.yml
+++ b/es-cluster-deployment.yml
@@ -16,7 +16,7 @@ metadata:
     app: elasticsearch
 spec:
   podManagementPolicy: OrderedReady
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: elasticsearch


### PR DESCRIPTION
Related to #28 

We can either deploy one master eligible node and set quorum to 1,
or deploy 3 master nodes and set quorum to 2.

If there are 2 master eligible nodes and quorum is 2 then
a node failure makes cluster inoperable.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>