### PR TITLE
Use configmaps in single role elasticsearch

### DIFF
--- a/es-cluster-deployment-roles.yml
+++ b/es-cluster-deployment-roles.yml
@@ -15,7 +15,7 @@ data:
     network:
       host: 0.0.0.0
     discovery:
-      zen.ping.unicast.hosts: ${ES_CLUSTER_SERVICE}
+      zen.ping.unicast.hosts: elasticsearch-cluster
       zen.minimum_master_nodes: 2
     node:
       master: true
@@ -40,7 +40,7 @@ data:
     network:
       host: 0.0.0.0
     discovery:
-      zen.ping.unicast.hosts: ${ES_CLUSTER_SERVICE}
+      zen.ping.unicast.hosts: elasticsearch-cluster
       zen.minimum_master_nodes: 1
     node:
       master: false
@@ -78,8 +78,6 @@ spec:
         image: ' '
         imagePullPolicy: IfNotPresent
         env:
-        - name: SERVICE
-          value: elasticsearch-cluster
         - name: LOG_LEVEL
           value: info
         resources:
@@ -135,8 +133,6 @@ spec:
       containers:
       - name: elasticsearch
         env:
-        - name: SERVICE
-          value: elasticsearch-cluster
         - name: LOG_LEVEL
           value: info
         image: ' '

--- a/es-cluster-deployment.yml
+++ b/es-cluster-deployment.yml
@@ -1,4 +1,25 @@
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elasticsearch-conf
+  labels:
+    app: elasticsearch
+data:
+  elasticsearch.yml: |
+    cluster:
+      name: elasticsearch
+    node:
+      name: ${HOSTNAME}
+    network:
+      host: 0.0.0.0
+    discovery:
+      zen.ping.unicast.hosts: elasticsearch-cluster
+      zen.minimum_master_nodes: 2
+    path:
+      data: /elasticsearch/persistent/elasticsearch/data
+      logs: /elasticsearch/logs
+---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -29,8 +50,6 @@ spec:
       containers:
       - name: elasticsearch
         env:
-        - name: SERVICE
-          value: elasticsearch-cluster
         - name: LOG_LEVEL
           value: info
         - name: NODE_QUORUM
@@ -52,10 +71,16 @@ spec:
         volumeMounts:
         - mountPath: /elasticsearch/persistent
           name: elasticsearch-persistent
+        - mountPath: /etc/elasticsearch/elasticsearch.yml
+          subPath: elasticsearch.yml
+          name: elasticsearch-conf
       securityContext: {}
       volumes:
-      - emptyDir: {}
-        name: elasticsearch-persistent
+      - name: elasticsearch-persistent
+        emptyDir: {}
+      - name: elasticsearch-conf
+        configMap:
+          name: elasticsearch-conf
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Use configmaps in a snigle role elasticsearch deployment. This allows aligns with multi-role deployment. It also allows easily change images - the configuration stays the same.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>