### PR TITLE
Remove node quorum env variable

### DIFF
--- a/es-cluster-deployment.yml
+++ b/es-cluster-deployment.yml
@@ -52,8 +52,6 @@ spec:
         env:
         - name: LOG_LEVEL
           value: info
-        - name: NODE_QUORUM
-          value: "2"
         image: ' '
         imagePullPolicy: IfNotPresent
         ports:


### PR DESCRIPTION
`NODE_QUORUM` env var is not needed. The value It's hardcoded in configmap.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>